### PR TITLE
use a reconnect method instead of clone

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -288,7 +288,7 @@ checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
 
 [[package]]
 name = "rust-vector-logger"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "env_logger",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-vector-logger"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Cesar Augusto Sanchez <cesan3@gmail.com>"]
 edition = "2021"
 description = "A simple logger for Rust that logs to a vector"


### PR DESCRIPTION
TcpStream can't be cloned, so the most appropriate way of handling this is using a reconnect method instead